### PR TITLE
Fix setup-tunnel.sh on GCP platform

### DIFF
--- a/tpl/aws/terraform/variables.tf
+++ b/tpl/aws/terraform/variables.tf
@@ -56,5 +56,6 @@ variable "aws_amis" {
   default = {
     us-east-1 = "ami-1d4e7a66"
     eu-central-1 = "ami-958128fa"
+    eu-west-1 = "ami-785db401"
   }
 }

--- a/tpl/gcp/setup-tunnel.sh.erb
+++ b/tpl/gcp/setup-tunnel.sh.erb
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 BASTION_IP="$(terraform output -state=terraform/terraform.tfstate bastion_ip)"
-ssh -D 5000 -fNC kite@$BASTION_IP -i <%= @values['kite']['public_key_path'] %>
+ssh -D 5000 -fNC kite@$BASTION_IP -i <%= @values['kite']['private_key_path'] %>
 
 export BOSH_ALL_PROXY=socks5://localhost:5000


### PR DESCRIPTION
- Add AMI for eu-west-1 AWS zone
- Fix setup-tunnel.sh for GCP platform
