### PR TITLE
Fixed reserved ip range rendering for AWS

### DIFF
--- a/lib/kite.rb
+++ b/lib/kite.rb
@@ -1,5 +1,6 @@
 require 'erb'
 require 'yaml'
+require 'ipaddr'
 require 'thor'
 
 require 'kite/version'

--- a/lib/kite/helpers.rb
+++ b/lib/kite/helpers.rb
@@ -28,4 +28,32 @@ module Kite::Helpers
     cloud_config
   end
 
+  # Returns subnet's IP range slice in a BOSH manifest-compatible way
+  def ip_range(subnet, range)
+
+    subnet = subnet.to_a # Turn subnet into array representation to be DRY
+
+    case range
+    when Integer
+      raise Kite::Error, 'Range number less than one in ip_range()' if range < 1
+
+      subnet[0].to_s + '-' + subnet[range].to_s
+
+    when Array
+      raise Kite::Error, 'Invalid number of elements in ip_range()' unless range.length == 2
+      raise Kite::Error, 'Second index is less than the first one in ip_range()' if range.last < range.first
+
+      subnet[range.first].to_s + '-' + subnet[range.last].to_s
+
+    when Range
+      raise Kite::Error, 'Second index is less than the first one in ip_range()' if range.last < range.first
+
+      range = range.to_a
+      subnet[range.first].to_s + '-' + subnet[range.last].to_s
+
+    else
+      raise Kite::Error, 'Unsupported range type for ip_range()'
+    end
+  end
+
 end

--- a/lib/kite/render.rb
+++ b/lib/kite/render.rb
@@ -18,6 +18,8 @@ module Kite
         directory("#{cloud}/deployments",                    'deployments')
 
       when "concourse"
+        @private_subnet = IPAddr.new(@values['aws']['private_subnet']['network']).to_range.to_a if options[:cloud] == 'aws'
+
         template("#{options[:cloud]}/deployments/concourse/cloud-config.yml.erb", "deployments/concourse/cloud-config.yml")
         template("#{options[:cloud]}/deployments/concourse/concourse.yml.erb", "deployments/concourse/concourse.yml")
 

--- a/spec/kite_spec.rb
+++ b/spec/kite_spec.rb
@@ -9,4 +9,38 @@ RSpec.describe Kite do
     tc = Kite::Cloud.new(Kite::Core.new, 'test_cloud')
     expect(tc.name).not_to be 'test_cloud'
   end
+
+  context Kite::Helpers do
+    context "ip_range()" do
+      include Kite::Helpers
+
+      subnet = IPAddr.new('10.0.0.0/24').to_range
+
+      it "can render a BOSH manifest-compatible ip range from a subnet" do
+        res_int       = ip_range(subnet, 10)
+        res_arr       = ip_range(subnet, [0, 10])
+        res_range     = ip_range(subnet, (0..10))
+
+        is_successful = res_int == res_arr && res_arr == res_range
+
+        expect(is_successful).to eql true
+      end
+
+      it "throws errors on invalid input" do
+        begin
+          ip_range(subnet, 'ten')
+        rescue Kite::Error => e
+          expect(e.message).to eql "Unsupported range type for ip_range()"
+        end
+      end
+
+      it "validates input data" do
+        begin
+          ip_range(subnet, (10..1))
+        rescue Kite::Error => e
+          expect(e.message).to eql "Second index is less than the first one in ip_range()"
+        end
+      end
+    end
+  end
 end

--- a/tpl/aws/deployments/concourse/cloud-config.yml.erb
+++ b/tpl/aws/deployments/concourse/cloud-config.yml.erb
@@ -55,8 +55,8 @@ networks:
   - az: z1
     range: <%= @values['aws']['private_subnet']['network'] %>
     gateway: <%= @values['aws']['private_subnet']['gateway'] %>
-    reserved: [10.0.20.1-10.0.20.10]
-    dns: [10.0.20.8]
+    reserved: [<%= ip_range(@private_subnet, (1..10)) %>]
+    dns: [<%= @private_subnet[8].to_s %>]
     cloud_properties: {subnet: <%= @tf_output['platform_subnet_id'] %>}
 - name: vip
   type: vip


### PR DESCRIPTION
Maybe it would be better to unify aws and gcp private subnet fields in `config/cloud.yml`