### PR TITLE
Upgrade Bosh AWS CPI to fix issue: Ruby 2.3.x and older are not compa…

### DIFF
--- a/tpl/aws/deployments/bosh/cpi.yml
+++ b/tpl/aws/deployments/bosh/cpi.yml
@@ -3,9 +3,9 @@
   path: /releases/-
   value:
     name: bosh-aws-cpi
-    version: 65
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=65
-    sha1: 26b3a5c43e6f82594a373309a495660d6db26254
+    version: 67
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=67
+    sha1: cfcbc98affa9cad674087ab6b8bd4b1188b18439
 
 - type: replace
   path: /resource_pools/name=vms/stemcell?


### PR DESCRIPTION
…tible with OpenSSL 1.1.x

https://github.com/rvm/rvm/issues/4112